### PR TITLE
Enable set the correct content type header

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Input              | Type             | Required | Default      | Description
 | `delete-removed` | boolean / string | No       | false        | Removes files in S3, that are not available in the local copy of the directory 
 | `noCache`        | boolean          | No       | false        | Use this parameter to specify `Cache-Control: no-cache, no-store, must-revalidate` header 
 | `private`        | boolean          | No       | false        | Upload files with private ACL, needed for S3 static website hosting
-
+| `ext`            | boolean          | No       | false        | Enables to set the correct content type header when files has no extension. For example, when the s3 bucket is used for webhosting and there is need to access paths like `/about` instead of `/about.html` so its possible to upload file named `about` and set `--ext html`
 
 ### Example `workflow.yml` with S3 Deploy Action
 
@@ -63,6 +63,7 @@ jobs:
             delete-removed: true
             no-cache: true
             private: true
+            ext: true
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   private:
     description: 'Upload files with private ACL, needed for S3 static website hosting'
     required: false
+  private:
+    description: 'Enables to set the correct content type header when files has no extension'
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
   private:
     description: 'Upload files with private ACL, needed for S3 static website hosting'
     required: false
-  private:
+  ext:
     description: 'Enables to set the correct content type header when files has no extension'
     required: false
 runs:

--- a/deploy.js
+++ b/deploy.js
@@ -3,7 +3,7 @@ const exec = require('@actions/exec');
 
 let deploy = function (params) {
   return new Promise((resolve, reject) => {
-    const { folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private } = params;
+    const { folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private, ext } = params;
 
     const distIdArg = distId ? `--distId ${distId}` : '';
     const invalidationArg = distId ? `--invalidate "${invalidation}"` : '';
@@ -15,6 +15,7 @@ let deploy = function (params) {
         : '';
     const noCacheArg = noCache ? '--noCache' : '';
     const privateArg = private ? '--private' : '';
+    const extArg = ext ? '--ext' : '';
 
     try {
       const command = `npx s3-deploy@1.4.0 ./** \
@@ -27,7 +28,8 @@ let deploy = function (params) {
                         ${invalidationArg} \
                         ${deleteRemovedArg} \
                         ${noCacheArg} \
-                        ${privateArg} `;
+                        ${privateArg} \
+                        ${extArg}`;
 
       const cwd = path.resolve(folder);
       exec.exec(command, [], { cwd }).then(resolve).catch(reject);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1042,8 +1042,9 @@ async function run() {
     const deleteRemoved = core.getInput('delete-removed') || false;
     const noCache = getBooleanInput('no-cache');
     const private = getBooleanInput('private');
-
-    await deploy({ folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private });
+    const ext = getBooleanInput('ext');
+    
+    await deploy({ folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private, ext });
   } catch (error) {
     core.setFailed(error.message);
   }
@@ -1076,7 +1077,7 @@ const exec = __webpack_require__(986);
 
 let deploy = function (params) {
   return new Promise((resolve, reject) => {
-    const { folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private } = params;
+    const { folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private, ext } = params;
 
     const distIdArg = distId ? `--distId ${distId}` : '';
     const invalidationArg = distId ? `--invalidate "${invalidation}"` : '';
@@ -1088,6 +1089,7 @@ let deploy = function (params) {
         : '';
     const noCacheArg = noCache ? '--noCache' : '';
     const privateArg = private ? '--private' : '';
+    const extArg = ext ? '--ext' : '';
 
     try {
       const command = `npx s3-deploy@1.4.0 ./** \
@@ -1100,7 +1102,8 @@ let deploy = function (params) {
                         ${invalidationArg} \
                         ${deleteRemovedArg} \
                         ${noCacheArg} \
-                        ${privateArg} `;
+                        ${privateArg} \
+                        ${extArg}`;
 
       const cwd = path.resolve(folder);
       exec.exec(command, [], { cwd }).then(resolve).catch(reject);

--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@ async function run() {
     const deleteRemoved = core.getInput('delete-removed') || false;
     const noCache = getBooleanInput('no-cache');
     const private = getBooleanInput('private');
-
-    await deploy({ folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private });
+    const ext = getBooleanInput('ext');
+    
+    await deploy({ folder, bucket, bucketRegion, distId, invalidation, deleteRemoved, noCache, private, ext });
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
`--ext`

> Enables to set the correct content type header when files has no extension. For example, when the s3 bucket is used for webhosting and there is need to access paths like /about instead of /about.html so its possible to upload file named about and set --ext html

ref: [s3-deploy](https://www.npmjs.com/package/s3-deploy)